### PR TITLE
1. fix bug for apply function; 2. add support of MARGIN=c(1,2) for apply function.

### DIFF
--- a/R/ddmatrix_apply.R
+++ b/R/ddmatrix_apply.R
@@ -12,28 +12,54 @@
 
 # Agreement occurs for ICTXT=1/MARGIN=2 and ICTXT=2/MARGIN=1
 
+# For MARGIN=c(1,2), it is assumed that FUN is a one-to-one mapping 
+# function which will not change the dimension of ddmatrix.
+
 setMethod("apply", signature(X="ddmatrix"),
   function(X, MARGIN, FUN, ..., reduce=FALSE, proc.dest="all")
   {
     # idiot proofing
     if (missing(MARGIN))
       comm.stop('argument "MARGIN" is missing, with no default')
-    else if (MARGIN != 1 && MARGIN != 2)
-      comm.stop('argument "MARGIN" must be 1 or 2 for a distributed matrix')
-    
+    else if (MARGIN != 1 && MARGIN != 2 && !all(MARGIN == c(1,2)))
+      comm.stop('argument "MARGIN" must be 1, 2 or c(1,2) for a distributed matrix')
+
     oldCTXT <- X@ICTXT
     oldbldim <- X@bldim
-    
+
+    # Margin = c(1,2)
+    if (all(MARGIN == c(1,2))) {
+      resultOK <- FALSE
+      if(ownany(X)){
+        olddim <- dim(X@Data)
+        X@Data <- apply(X=X@Data, MARGIN=MARGIN, FUN=FUN, ...)
+        # check whether or not dimesion matches
+        # currently it only supports one-to-one mapping function
+        resultOK <- all(dim(X@Data) == olddim)
+      }else{
+        resultOK <- TRUE
+      }
+      resultOK <- comm.all(resultOK)
+      if(!resultOK) {
+        comm.stop('apply only supports one-to-one mapping funcion when margin=c(1,2)')
+      }
+      return(X)
+    }
     # Row margin
-    if (MARGIN==1){
+    else if (MARGIN==1){
       if (X@ICTXT!=2){
         fudge <- max(floor(X@bldim/base.blacs(X@ICTXT)$NPCOLS), 1)
         X <- dmat.reblock(dx=X, bldim=fudge, ICTXT=2)
       }
       
-      tmp <- apply(X@Data, MARGIN=1, FUN=FUN)
-      
-      if (is.list(tmp)){
+      if(ownany(X)){
+        tmp <- apply(X@Data, MARGIN=1, FUN=FUN, ...)
+      }else{
+        # it is unsafe to apply on X@Data if X does not hold any submatrix.
+        tmp <- NULL
+      }
+       ## The following block should be reconsidered since tmp can be NULL.
+      if (!is.null(tmp) && is.list(tmp)){
         if (!all(sapply(tmp, is.numeric)))
           comm.stop("Error : list object contains non-numeric data")
         if (proc.dest=='all')
@@ -41,24 +67,49 @@ setMethod("apply", signature(X="ddmatrix"),
         else
           return( gather(tmp, proc.dest=proc.dest) )
       }
-      
-      else if (!is.matrix(tmp))
+
+      else if (!is.null(tmp) && !is.matrix(tmp)){
         dim(tmp) <- c(base::length(tmp), 1L)
-        
-      X@Data <- tmp
+      }else if (!is.null(tmp) && is.matrix(tmp)){
+        # when apply on margin=1, the returned matrix should be transposed back
+        tmp <- t(tmp) 
+      }
+
+      # now we need to determine new ddmatrix global dimension.
+      # row number remains same with old ddmatrix.
+      # we need to get global column number which is the maxium of local new column number.
+      if(ownany(X)) {
+        lcolnum <- dim(tmp)[2L]
+      } else {
+        # if X does not hold any submatrix, it is 0.
+        lcolnum <- 0
+      }
+      gcolnum <- comm.max(lcolnum)
       
-      X@ldim <- dim(X@Data)
-      X@dim[2L] <- X@ldim[2L]
+      if(ownany(X)){
+        X@dim <- c(X@dim[1L], gcolnum)
+        X@Data <- tmp
+        X@ldim <- dim(X@Data)
+      }else{
+        X@dim <- c(X@dim[1L], gcolnum)
+      }
+      
     }
     # Column margin
     else if (MARGIN==2){
       if (X@ICTXT!=1)
         fudge <- max(floor(X@bldim/base.blacs(X@ICTXT)$NPROWS), 1)
         X <- dmat.reblock(dx=X, bldim=X@bldim/2, ICTXT=1)
+
+      if(ownany(X)) {
+        tmp <- apply(X@Data, MARGIN=2, FUN=FUN, ...)
+      } else {
+        # it is unsafe to apply on X@Data if X does not hold any submatrix.
+        tmp <- NULL
+      }
       
-      tmp <- apply(X@Data, MARGIN=2, FUN=FUN, ...)
-      
-      if (is.list(tmp)){
+      ## The following block should be reconsidered since tmp can be NULL.
+      if (!is.null(tmp) && is.list(tmp)){
         if (!all(sapply(tmp, is.numeric)))
           comm.stop("Error : list object contains non-numeric data")
         if (proc.dest=='all')
@@ -66,15 +117,29 @@ setMethod("apply", signature(X="ddmatrix"),
         else
           return( gather(tmp, proc.dest=proc.dest) )
       }      
-      else if (!is.matrix(tmp))
+      else if (!is.null(tmp) && !is.matrix(tmp))
         dim(tmp) <- c(1L, base::length(tmp))
         
-      X@Data <- tmp
+      # now we need to determine new ddmatrix global dimension.
+      # column number remains same with old ddmatrix.
+      # we need to get global row number which is the maxium of local row number of new submatrices.
+      if(ownany(X)) {
+        lrownum <- dim(tmp)[1L]
+      } else {
+        lrownum <- 0
+      }
+      grownum <- comm.max(lrownum)
       
-      X@ldim <- dim(X@Data)
-      X@dim[1L] <- X@ldim[1L]
+      if(ownany(X)){
+        X@dim <- c(grownum, X@dim[2L])
+        X@Data <- tmp
+        X@ldim <- dim(X@Data)
+      }else{
+        X@dim <- c(grownum, X@dim[2L])
+      }
+
     }
-  
+
   if (reduce==TRUE){
     if (MARGIN==1)
       if (X@dim[2L]==1)
@@ -92,11 +157,16 @@ setMethod("apply", signature(X="ddmatrix"),
     X <- as.matrix(X, proc.dest=proc.dest)
   else if (reduce=="vector")
     X <- as.vector(X, proc.dest=proc.dest)
-    
+
+   
     if (is.ddmatrix(X))
       if (X@ICTXT != oldCTXT)
         X <- dmat.reblock(dx=X, bldim=oldbldim, ICTXT=oldCTXT)
-      
+    
+    if (is.ddmatrix(X) && length(MARGIN)==1 && MARGIN==1 && ncol(X)!=1) {
+        # make the returned matrix has the same behaviour with R original apply function on margin = 1
+        X <- t(X)
+    }
     return(X)
   }
 )


### PR DESCRIPTION
I fix several bugs for apply function and add support of MARGIN=c(1,2) for apply function.
## bug fixing part
There are some bugs in original apply implementation. The code in [this gist](https://gist.github.com/wangzk/bbacf86d17d1aa18eae0#file-test_ddmatrix_apply-r) will reproduce the bug.
I compare the behavior of apply function on ddmatrix with behavior on  R native matrix in the test code. 
Run this code with `mpirun -np 3 Rscript ./testApply.R`
Most of the bugs I find is with the situation that some ddmatrix object X does not hold any submatrix when apply is called.

## support for MARGIN=c(1,2)
When we call apply with MARGIN=c(1,2), it means that apply the FUN on every element in the matrix.
The simplest situation is applying an one-to-one mapping function *FUN* on matrix, which will result in a new ddmatrix with the same dimension with original matrix . In this situation, we can directly apply the function FUN on ddmatrix X's "X@Data" slot and return X back. 
If the function FUN changes the length of the matrix ( for example, FUN is a function returning a vector of length 2), it may require recalculation on ldim and dim.
Currently, my code only supports one-to-one mapping function.



