### PR TITLE
use 'useAsDefault' to override implicit generic formals

### DIFF
--- a/R/as.vector.r
+++ b/R/as.vector.r
@@ -43,7 +43,8 @@
 setGeneric(name="as.vector", 
   function(x, ...)
     standardGeneric("as.vector"),
-  package="pbdDMAT"
+  useAsDefault=function(x, ...) 
+    base::as.vector(x, ...)
 )
 
 
@@ -60,14 +61,3 @@ setMethod("as.vector", signature(x="ddmatrix"),
     return( ret )
   }
 )
-
-
-
-#' @rdname as.vector
-#' @export
-setMethod("as.vector", signature(x="ANY"), 
-  function(x, mode="any") 
-    base::as.vector(x=x, mode=mode)
-)
-
-


### PR DESCRIPTION
Not only is this "best practice", but it fixes compatibility with R-devel, where 'as.vector' has become an internal generic. Note that I only did minimal testing, hopefully you can take it from here, as I have a dozen other packages to fix. Thanks!

PS: In general, I would avoid overriding formals from base implicit generics. This might be unavoidable in this case, but it's going to cause conflicts with other packages defining methods on as.vector.